### PR TITLE
fix: using labels instead of annotations for finding project namespace

### DIFF
--- a/controllers/get_project_in_namespace.go
+++ b/controllers/get_project_in_namespace.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/open-component-model/mpas-project-controller/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/open-component-model/mpas-project-controller/api/v1alpha1"
 )
 
 // GetProjectFromObjectNamespace returns the Project from the annotation of the current namespace that an object
@@ -19,7 +20,7 @@ func GetProjectFromObjectNamespace(ctx context.Context, c client.Client, obj cli
 		return nil, fmt.Errorf("failed to retrieve namespace for object: %w", err)
 	}
 
-	v, ok := ns.Annotations[v1alpha1.ProjectKey]
+	v, ok := ns.Labels[v1alpha1.ProjectKey]
 	if !ok {
 		return nil, fmt.Errorf("project key %s not found on namespace", v1alpha1.ProjectKey)
 	}

--- a/controllers/productdeploymentgenerator_controller_test.go
+++ b/controllers/productdeploymentgenerator_controller_test.go
@@ -52,7 +52,7 @@ func TestProductDeploymentGeneratorReconciler(t *testing.T) {
 	testNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace",
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				projectv1.ProjectKey: "project",
 			},
 		},
@@ -266,7 +266,7 @@ func TestProductDeploymentGeneratorReconcilerWithValueFile(t *testing.T) {
 	testNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace",
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				projectv1.ProjectKey: "project",
 			},
 		},

--- a/controllers/productdeploymentpipeline_controller_test.go
+++ b/controllers/productdeploymentpipeline_controller_test.go
@@ -35,7 +35,7 @@ func TestProductDeploymentPipelineReconciler(t *testing.T) {
 	testNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace",
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				projectv1.ProjectKey: "project",
 			},
 		},

--- a/controllers/validation_controller_test.go
+++ b/controllers/validation_controller_test.go
@@ -35,7 +35,7 @@ func TestBasicReconcile(t *testing.T) {
 	testNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace",
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				projectv1.ProjectKey: "project",
 			},
 		},
@@ -194,7 +194,7 @@ func TestRemovingGitRepositoryWhenPullRequestIsMerged(t *testing.T) {
 	testNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace",
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				projectv1.ProjectKey: "project",
 			},
 		},

--- a/docs/release_notes/v0.6.0.md
+++ b/docs/release_notes/v0.6.0.md
@@ -1,0 +1,9 @@
+# Release 0.6.0
+
+- fix: using labels instead of annotations for finding project namespace #70
+- add mend scans (#68)
+- build(deps): bump google.golang.org/grpc from 1.57.0 to 1.57.1 (#69)
+- Update actions/checkout to v4 (#67)
+- remove (#65)
+- Add blackduck scans (#63)
+- Adding a target reconciler (#59)

--- a/pkg/version/release.go
+++ b/pkg/version/release.go
@@ -5,7 +5,7 @@
 package version
 
 // ReleaseVersion is the version number in semver format "vX.Y.Z", prefixed with "v".
-var ReleaseVersion = "v0.5.1"
+var ReleaseVersion = "v0.6.0"
 
 // ReleaseCandidate is the release candidate ID in format "rc.X", which will be appended to the release version.
 var ReleaseCandidate = "rc.1"


### PR DESCRIPTION
## Description
External Secrets is using label matching instead of annotations so it couldn't find the new project namespace.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
